### PR TITLE
Add flag to open URL in browser for share subcommand

### DIFF
--- a/cmd/gp/usage.go
+++ b/cmd/gp/usage.go
@@ -43,7 +43,10 @@ func usageShare() {
 	fmt.Println(`usage: goplayground share [gofile]
 
 "share" generates share URL on Go Playground.
-If [gofile] is not specify, it compiles and runs from stdin.`)
+If [gofile] is not specify, it compiles and runs from stdin.
+
+The flags are:
+	-open	open url in browser for share`)
 }
 
 func usageDownload() {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/tenntenn/goplayground
 go 1.12
 
 require (
+	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/pkg/errors v0.8.1
 	github.com/rogpeppe/go-internal v1.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4 h1:49lOXmGaUpV9Fz3gd7TFZY106KVlPVa5jcYD1gaQf98=
+github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4/go.mod h1:4OwLy04Bl9Ef3GJJCoec+30X3LQs/0/m4HFRt/2LUSA=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/rogpeppe/go-internal v1.3.0 h1:RR9dF3JtopPvtkroDZuVD7qquD0bnHlKSqaQhgwt8yk=


### PR DESCRIPTION
Add `-open` flag to open URL in browser for `share` subcommand.

```
$ gp share -open main.go
```