### PR TITLE
README: Add command examples ignoring hidden files

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ $ gp run a.go b.go
 $ find . -type f | xargs gp run
 ```
 
+```
+$ find . -type f -not -path '*/\.*' | xargs gp run
+```
+
 ### Format
 
 ```
@@ -48,6 +52,10 @@ $ gp format a.go b.go
 $ find . -type f | xargs gp format
 ```
 
+```
+$ find . -type f -not -path '*/\.*' | xargs gp format
+```
+
 ### Share
 
 ```
@@ -60,6 +68,10 @@ $ gp share a.go b.go
 
 ```
 $ find . -type f | xargs gp share
+```
+
+```
+$ find . -type f -not -path '*/\.*' | xargs gp share
 ```
 
 ### Download


### PR DESCRIPTION
Sorry for the change without raising an issue ✋ Feel free to close if you don't like this PR.

# What
Add the command examples that ignore hidden files and files under hidden directories to `README` .

# Why
I guess there are many cases where a target directory has some kind of hidden files or hidden directories like `./git` or `.gitignore`. (Actually, I included git-related files by mistake when I used this tool 🤣 )
In most cases, hidden files should not be caught by this tool.