### PR TITLE
Fix endpoint for -go2 option

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ $ gp dl https://play.golang.org/p/sTkdodLtokQ
 $ gp dl -dldir=output https://play.golang.org/p/sTkdodLtokQ
 ```
 
-## Try generics codes with go2goplay.golang.org
+## Try generics codes with gotipplay.golang.org
 
 ```
 $ gp format -go2 example.go2

--- a/client.go
+++ b/client.go
@@ -12,8 +12,8 @@ import (
 const (
 	// BaseURL is the default base URL of Go Playground.
 	BaseURL = "https://play.golang.org"
-	// Go2GoBaseURL is the base URL of go2goplay.golang.org.
-	Go2GoBaseURL = "https://go2goplay.golang.org"
+	// Go2BaseURL is the base URL for -go2 option.
+	Go2BaseURL = "https://gotipplay.golang.org"
 	// Version is version of using Go Playground.
 	Version = "2"
 )

--- a/cmd/gp/main.go
+++ b/cmd/gp/main.go
@@ -34,7 +34,7 @@ func main() {
 		go2go, asJSON, imports, open bool
 		dldir, outputpath            string
 	)
-	fset.BoolVar(&go2go, "go2", false, "use go2goplay.golang.org")
+	fset.BoolVar(&go2go, "go2", false, "use "+goplayground.Go2BaseURL)
 	fset.BoolVar(&asJSON, "json", false, "output as JSON for run or format")
 	fset.BoolVar(&imports, "imports", false, "use goimports for format")
 	fset.BoolVar(&open, "open", false, "open url in browser for share")
@@ -50,7 +50,7 @@ func main() {
 	}
 
 	if go2go {
-		p.cli.BaseURL = goplayground.Go2GoBaseURL
+		p.cli.BaseURL = goplayground.Go2BaseURL
 	}
 
 	switch os.Args[1] {


### PR DESCRIPTION
Hi. Currently, `-go2` option is not working correctly.
This PR changes the endpoint for `-go2`.



https://user-images.githubusercontent.com/44139130/144732735-f496b1c0-1df6-4a55-a64d-a254fd229607.mov

